### PR TITLE
chore: add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+starter/node_modules


### PR DESCRIPTION
Add .gitignore file mainly to include node_modules under it, as students who use this starter may experience lagging IDE when `npm install` is done in application root with a Git plugin connected.